### PR TITLE
docs: 添加了修复 Git for Windows 报错的内容

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,19 +83,19 @@ git clone https://github.com/nolebase/nolebase
 #### 使用的是 Windows 吗
 
 > [!IMPORTANT]
-> 如果你使用的是 [Git for Windows](https://gitforwindows.org/) ，那么可能会在执行上述命令时遇到类似这样的报错：
+> 如果你使用的是 [Git for Windows](https://gitforwindows.org/) ，那么可能会在执行上述命令时，遇到类似这样的报错：
 > 
 > ```PowerShell
 > PS D:\> git clone https://github.com/nolebase/nolebase
 > ...
-> error: invalid path '编目 Catalog/文章/Python, Go, and TypeScript: My Insights on Crafting Command Line Interfaces.md'
+> error: invalid path 'x: xxx.md'
 > fatal: unable to checkout working tree
 > warning: Clone succeeded, but checkout failed.
 > You can inspect what was checked out with 'git status'
 > and retry with 'git restore --source=HEAD :/'
 > ```
 > 
-> 这是 [Git for Windows](https://gitforwindows.org/) 的一个 [bug](https://github.com/git-for-windows/git/issues/2777) 。更具体的说，是由于 [NTFS 文件系统中对文件名的限制](https://github.com/microsoft/WSL/issues/2689#issuecomment-346740836)导致的。
+> 这是 [Git for Windows](https://gitforwindows.org/) 的默认配置导致的[问题](https://github.com/git-for-windows/git/issues/2777)。
 > 
 > 你可以在命令行窗口中输入下面的命令来解决这个问题：
 > ```PowerShell

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ git clone https://github.com/nolebase/nolebase
 #### 使用的是 Windows 吗
 
 > [!IMPORTANT]
-> 如果你使用的是 Windows，并且使用的是 [Git for Windows](https://gitforwindows.org/) ，那么你可能会在使用上面的命令的时候遇到类似这样的报错：
+> 如果你使用的是 [Git for Windows](https://gitforwindows.org/) ，那么可能会在执行上述命令时遇到类似这样的报错：
 > 
 > ```PowerShell
 > PS D:\> git clone https://github.com/nolebase/nolebase

--- a/README.md
+++ b/README.md
@@ -80,6 +80,29 @@
 git clone https://github.com/nolebase/nolebase
 ```
 
+#### 使用的是 Windows 吗
+
+> [!IMPORTANT]
+> 如果你使用的是 Windows，并且使用的是 [Git for Windows](https://gitforwindows.org/) ，那么你可能会在使用上面的命令的时候遇到类似这样的报错：
+> 
+> ```PowerShell
+> PS D:\> git clone https://github.com/nolebase/nolebase
+> ...
+> error: invalid path '编目 Catalog/文章/Python, Go, and TypeScript: My Insights on Crafting Command Line Interfaces.md'
+> fatal: unable to checkout working tree
+> warning: Clone succeeded, but checkout failed.
+> You can inspect what was checked out with 'git status'
+> and retry with 'git restore --source=HEAD :/'
+> ```
+> 
+> 这是 [Git for Windows](https://gitforwindows.org/) 的一个 [bug](https://github.com/git-for-windows/git/issues/2777) 。更具体的说，是由于 [NTFS 文件系统中对文件名的限制](https://github.com/microsoft/WSL/issues/2689#issuecomment-346740836)导致的。
+> 
+> 你可以在命令行窗口中输入下面的命令来解决这个问题：
+> ```PowerShell
+> git config --global core.protectNTFS false
+> ```
+> [StackOverflow](https://stackoverflow.com/questions/63727594/github-git-checkout-returns-error-invalid-path-on-windows) 上有更多的讨论。
+
 ### 如何使用、运行或者部署
 
 完成了下载了吗？很好，恭喜你已经完成了很艰难的一步！

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ git clone https://github.com/nolebase/nolebase
 > ```PowerShell
 > git config --global core.protectNTFS false
 > ```
-> [StackOverflow](https://stackoverflow.com/questions/63727594/github-git-checkout-returns-error-invalid-path-on-windows) 上有更多的讨论。
 
 ### 如何使用、运行或者部署
 

--- a/笔记/index.md
+++ b/笔记/index.md
@@ -60,6 +60,29 @@
 git clone https://github.com/nolebase/nolebase
 ```
 
+#### 使用的是 Windows 吗
+
+> [!IMPORTANT]
+> 如果你使用的是 [Git for Windows](https://gitforwindows.org/) ，那么可能会在执行上述命令时，遇到类似这样的报错：
+> 
+> ```PowerShell
+> PS D:\> git clone https://github.com/nolebase/nolebase
+> ...
+> error: invalid path 'x: xxx.md'
+> fatal: unable to checkout working tree
+> warning: Clone succeeded, but checkout failed.
+> You can inspect what was checked out with 'git status'
+> and retry with 'git restore --source=HEAD :/'
+> ```
+> 
+> 这是 [Git for Windows](https://gitforwindows.org/) 的默认配置导致的[问题](https://github.com/git-for-windows/git/issues/2777)。
+> 
+> 你可以在命令行窗口中输入下面的命令来解决这个问题：
+> ```PowerShell
+> git config --global core.protectNTFS false
+> ```
+
+
 ### 如何使用、运行或者部署
 
 完成了下载了吗？很好，恭喜你已经完成了很艰难的一步！


### PR DESCRIPTION
前文提要：#35 
如上所述，``Git for Windows`` 用户很可能会在 clone 时报错。因此在文档中加入了修复的方法。
（不太会写文档，如有疏漏请多包涵~）